### PR TITLE
Attempted fixes for build.cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -26,7 +26,9 @@ Task("Clean")
             {
                 CleanDirectories(new DirectoryPath[] {
                         binDir, objDir, releaseDir });
-                DeleteFile(releaseZip);
+                if (FileExists(releaseZip)) {
+                    DeleteFile(releaseZip);
+                }
             });
 
 Task("Restore")
@@ -38,7 +40,7 @@ Task("Restore")
                         Source = new List<string> {
                             "https://www.nuget.org/api/v2/"
                         },
-                        ToolPath = ".nuget/nuget.exe"
+                        ToolPath = ".nuget/NuGet.exe"
                     });
             });
 


### PR DESCRIPTION
When I was trying to test out your PR (https://github.com/OmniSharp/omnisharp-server/pull/197), I got the following error on a clean clone:

```
$ cake -t=Setup

----------------------------------------
Setup
----------------------------------------
Building ./OmniSharp.sln

========================================
Clean
========================================
An error occured when executing task 'Clean'.
Error: The file '/Users/eliot/Dev/git/omnisharp-server/OmniSharp.zip' do not exist.
```

So I added a check to see if the file exists first before trying to delete. Then I got this error:

```
$ cake -t=Setup

----------------------------------------
Setup
----------------------------------------
Building ./OmniSharp.sln

========================================
Clean
========================================

========================================
Restore
========================================
An error occured when executing task 'Restore'.
Error: ApplicationName='/Users/eliot/Dev/git/omnisharp-server/.nuget/nuget.exe', CommandLine='restore "/Users/eliot/Dev/git/omnisharp-server/OmniSharp.sln" -Source "https://www.nuget.org/api/v2/" -NonInteractive', CurrentDirectory='/Users/eliot/Dev/git/omnisharp-server', Native error= Cannot find the specified file
```

I thought it might be a case-sensitivity issue so I fixed the path to `NuGet.exe`. However, I still get the same error when running. Aborting fort now but I thought you might want to take these changes anyway.

I'm using Cake Version 0.7.0.
